### PR TITLE
Update basic_multi.py

### DIFF
--- a/opstrat/basic_multi.py
+++ b/opstrat/basic_multi.py
@@ -86,7 +86,7 @@ def multi_plotter(spot_range=20, spot=100,
                 
             label=contract+' '+str(abb[op_list[i]['tr_type']])+' '+str(abb[op_list[i]['op_type']])+' ST: '+str(op_list[i]['strike'])
             sns.lineplot(x=x, y=y_list[i], label=label, alpha=0.5)
-            y+=np.array(y_list[i])
+            y+=np.array(y_list[i])*op_list[i]['quantity'] #Change this value with Quantities
         
         sns.lineplot(x=x, y=y, label='combined', alpha=1, color='k')
         plt.axhline(color='k', linestyle='--')


### PR DESCRIPTION
Added Quantity in option's legs dataset to create multiple quantities strategies.
Example:
op1={'op_type': 'c', 'strike': 215, 'tr_type': 's', 'op_pr': 7.63, 'quantity" : 25}
op2={'op_type': 'c', 'strike': 220, 'tr_type': 'b', 'op_pr': 5.35, 'quantity" : 50}
op3={'op_type': 'p', 'strike': 210, 'tr_type': 's', 'op_pr': 7.20, 'quantity" : 50}
op4={'op_type': 'p', 'strike': 205, 'tr_type': 'b', 'op_pr': 5.52, 'quantity" : 25}